### PR TITLE
Single- & Bulk-Export to VCF

### DIFF
--- a/app/src/main/java/ch/abwesend/privatecontacts/domain/repository/IAndroidContactLoadService.kt
+++ b/app/src/main/java/ch/abwesend/privatecontacts/domain/repository/IAndroidContactLoadService.kt
@@ -16,4 +16,5 @@ interface IAndroidContactLoadService {
     fun loadContactsAsFlow(searchConfig: ContactSearchConfig): ResourceFlow<List<IContactBase>>
     suspend fun loadAllContactsFull(): List<IContact>
     suspend fun resolveContact(contactId: IContactIdExternal): IContact
+    suspend fun resolveContacts(contactIds: Set<IContactIdExternal>): List<IContact>
 }

--- a/app/src/main/java/ch/abwesend/privatecontacts/domain/repository/IContactRepository.kt
+++ b/app/src/main/java/ch/abwesend/privatecontacts/domain/repository/IContactRepository.kt
@@ -35,6 +35,7 @@ interface IContactRepository {
     suspend fun findContactsWithNumberEndingOn(endOfPhoneNumber: String): List<ContactWithPhoneNumbers>
 
     suspend fun resolveContact(contactId: IContactIdInternal): IContact
+    suspend fun resolveContacts(contactIds: Set<IContactIdInternal>): List<IContact>
     suspend fun createContact(contactId: IContactIdInternal, contact: IContact): ContactSaveResult
     suspend fun updateContact(contactId: IContactIdInternal, contact: IContact): ContactSaveResult
     suspend fun deleteContacts(contactIds: Collection<IContactIdInternal>): ContactIdBatchChangeResult

--- a/app/src/main/java/ch/abwesend/privatecontacts/domain/service/ContactExportService.kt
+++ b/app/src/main/java/ch/abwesend/privatecontacts/domain/service/ContactExportService.kt
@@ -19,7 +19,6 @@ import ch.abwesend.privatecontacts.domain.service.interfaces.IVCardImportExportR
 import ch.abwesend.privatecontacts.domain.util.injectAnywhere
 import kotlinx.coroutines.withContext
 
-// TODO add unit tests
 class ContactExportService {
     private val dispatchers: IDispatchers by injectAnywhere()
     private val loadService: ContactLoadService by injectAnywhere()

--- a/app/src/main/java/ch/abwesend/privatecontacts/domain/service/ContactExportService.kt
+++ b/app/src/main/java/ch/abwesend/privatecontacts/domain/service/ContactExportService.kt
@@ -9,6 +9,7 @@ package ch.abwesend.privatecontacts.domain.service
 import android.net.Uri
 import ch.abwesend.privatecontacts.domain.lib.coroutine.IDispatchers
 import ch.abwesend.privatecontacts.domain.model.contact.ContactType
+import ch.abwesend.privatecontacts.domain.model.contact.IContact
 import ch.abwesend.privatecontacts.domain.model.importexport.ContactExportData
 import ch.abwesend.privatecontacts.domain.model.importexport.VCardCreateError
 import ch.abwesend.privatecontacts.domain.model.importexport.VCardCreateError.FILE_WRITING_FAILED
@@ -31,7 +32,14 @@ class ContactExportService {
         vCardVersion: VCardVersion,
     ): BinaryResult<ContactExportData, VCardCreateError> = withContext(dispatchers.default) {
         val contacts = loadService.loadFullContactsByType(sourceType)
+        exportContacts(targetFile, vCardVersion, contacts)
+    }
 
+    suspend fun exportContacts(
+        targetFile: Uri,
+        vCardVersion: VCardVersion,
+        contacts: List<IContact>,
+    ): BinaryResult<ContactExportData, VCardCreateError> = withContext(dispatchers.default) {
         val vCardResult = importExportRepository.exportContacts(contacts, vCardVersion)
 
         val fileWriteResult = vCardResult.mapValueToBinaryResult { createdVCards ->

--- a/app/src/main/java/ch/abwesend/privatecontacts/view/components/contactmenu/ContactMenuConfirmationDialogs.kt
+++ b/app/src/main/java/ch/abwesend/privatecontacts/view/components/contactmenu/ContactMenuConfirmationDialogs.kt
@@ -1,7 +1,9 @@
 package ch.abwesend.privatecontacts.view.components.contactmenu
 
+import android.net.Uri
 import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Column
+import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -12,8 +14,13 @@ import androidx.compose.ui.res.stringResource
 import ch.abwesend.privatecontacts.R
 import ch.abwesend.privatecontacts.domain.model.contact.IContactBase
 import ch.abwesend.privatecontacts.domain.model.contact.IContactBaseWithAccountInformation
+import ch.abwesend.privatecontacts.domain.model.importexport.VCardVersion
 import ch.abwesend.privatecontacts.view.components.dialogs.YesNoDialog
+import ch.abwesend.privatecontacts.view.components.inputs.VCardVersionField
+import ch.abwesend.privatecontacts.view.filepicker.CreateFileFilePickerLauncher
 import ch.abwesend.privatecontacts.view.model.ContactTypeChangeMenuConfig
+import ch.abwesend.privatecontacts.view.screens.importexport.extensions.ImportExportConstants
+import java.time.LocalDate
 
 @Composable
 fun ChangeContactTypeConfirmationDialog(
@@ -46,15 +53,16 @@ fun ChangeContactTypeConfirmationDialog(
 
 @Composable
 fun DeleteContactConfirmationDialog(
-    contacts: Set<IContactBase>,
+    numberOfContacts: Int,
     visible: Boolean,
     hideDialog: (delete: Boolean) -> Unit,
 ) {
     if (visible) {
-        @StringRes val titleRes = if (contacts.size == 1) R.string.delete_contact_title
-        else R.string.delete_contacts_title
-        val text = if (contacts.size == 1) stringResource(id = R.string.delete_contact_text)
-        else stringResource(id = R.string.delete_contacts_text, contacts.size)
+        @StringRes val titleRes =
+            if (numberOfContacts == 1) R.string.delete_contact_title else R.string.delete_contacts_title
+
+        val text = if (numberOfContacts == 1) stringResource(id = R.string.delete_contact_text)
+        else stringResource(id = R.string.delete_contacts_text, numberOfContacts)
 
         YesNoDialog(
             title = titleRes,
@@ -63,4 +71,55 @@ fun DeleteContactConfirmationDialog(
             onNo = { hideDialog(false) },
         )
     }
+}
+
+@ExperimentalMaterialApi
+@Composable
+fun ExportContactConfirmationDialog(
+    contacts: Set<IContactBase>,
+    visible: Boolean,
+    onExport: (targetFile: Uri, vCardVersion: VCardVersion) -> Unit,
+    onCancel: () -> Unit,
+) {
+    if (visible) {
+        val numberOfContacts = contacts.size
+        var vCardVersion: VCardVersion by remember { mutableStateOf(VCardVersion.default) }
+
+        val defaultFileName = createDefaultExportFileName(contacts, vCardVersion)
+
+        val launcher = CreateFileFilePickerLauncher.rememberCreateFileLauncher(
+            mimeType = ImportExportConstants.VCF_MAIN_MIME_TYPE,
+            defaultFilename = defaultFileName,
+            onFileSelected = { targetFile ->
+                targetFile?.let { onExport(it, vCardVersion) }
+            },
+        )
+
+        @StringRes val titleRes =
+            if (numberOfContacts == 1) R.string.export_contact_title else R.string.export_contacts_title
+
+        YesNoDialog(
+            title = titleRes,
+            yesButtonLabel = R.string.ok,
+            noButtonLabel = R.string.cancel,
+            onYes = { launcher.launch() },
+            onNo = onCancel,
+            text = {
+                VCardVersionField(vCardVersion) { newValue -> vCardVersion = newValue }
+            },
+        )
+    }
+}
+
+@Composable
+private fun createDefaultExportFileName(contacts: Set<IContactBase>, vCardVersion: VCardVersion): String {
+    val datePrefix = LocalDate.now().toString()
+    val versionInfix = vCardVersion.name
+    val contactPostfix = if (contacts.size == 1) {
+        contacts.first().displayName.replace(' ', '_').filter { it.isLetter() || it == '_' }
+    } else {
+        stringResource(id = R.string.selected_for_export)
+    }
+    val extension = ImportExportConstants.VCF_FILE_EXTENSION
+    return "${datePrefix}_${versionInfix}_$contactPostfix.$extension"
 }

--- a/app/src/main/java/ch/abwesend/privatecontacts/view/components/contactmenu/ContactMenuConfirmationDialogs.kt
+++ b/app/src/main/java/ch/abwesend/privatecontacts/view/components/contactmenu/ContactMenuConfirmationDialogs.kt
@@ -116,9 +116,11 @@ private fun createDefaultExportFileName(contacts: Set<IContactBase>, vCardVersio
     val datePrefix = LocalDate.now().toString()
     val versionInfix = vCardVersion.name
     val contactPostfix = if (contacts.size == 1) {
-        contacts.first().displayName.replace(' ', '_').filter { it.isLetter() || it == '_' }
+        contacts.first().displayName
+            .replace(' ', '_')
+            .filter { it.isLetter() || it == '_' }
     } else {
-        stringResource(id = R.string.selected_for_export)
+        "${stringResource(id = R.string.selected_for_export)}_${contacts.size}"
     }
     val extension = ImportExportConstants.VCF_FILE_EXTENSION
     return "${datePrefix}_${versionInfix}_$contactPostfix.$extension"

--- a/app/src/main/java/ch/abwesend/privatecontacts/view/components/contactmenu/ContactMenuItems.kt
+++ b/app/src/main/java/ch/abwesend/privatecontacts/view/components/contactmenu/ContactMenuItems.kt
@@ -1,7 +1,9 @@
 package ch.abwesend.privatecontacts.view.components.contactmenu
 
+import android.net.Uri
 import androidx.annotation.StringRes
 import androidx.compose.material.DropdownMenuItem
+import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -12,6 +14,7 @@ import androidx.compose.ui.res.stringResource
 import ch.abwesend.privatecontacts.R
 import ch.abwesend.privatecontacts.domain.model.contact.IContactBase
 import ch.abwesend.privatecontacts.domain.model.contact.IContactBaseWithAccountInformation
+import ch.abwesend.privatecontacts.domain.model.importexport.VCardVersion
 import ch.abwesend.privatecontacts.view.model.ContactTypeChangeMenuConfig
 
 @Composable
@@ -43,23 +46,49 @@ fun ChangeContactTypeMenuItem(
 
 @Composable
 fun DeleteContactMenuItem(
-    contacts: Set<IContactBase>,
+    numberOfContacts: Int,
     onCloseMenu: (delete: Boolean) -> Unit,
 ) {
-    var deleteConfirmationDialogVisible: Boolean by remember { mutableStateOf(false) }
-    val multipleContacts = contacts.size > 1
+    var dialogVisible: Boolean by remember { mutableStateOf(false) }
+    val multipleContacts = numberOfContacts > 1
 
-    DropdownMenuItem(onClick = { deleteConfirmationDialogVisible = true }) {
+    DropdownMenuItem(onClick = { dialogVisible = true }) {
         @StringRes val text = if (multipleContacts) R.string.delete_contacts else R.string.delete_contact
         Text(stringResource(id = text))
     }
 
     DeleteContactConfirmationDialog(
-        contacts = contacts,
-        visible = deleteConfirmationDialogVisible,
+        numberOfContacts = numberOfContacts,
+        visible = dialogVisible,
         hideDialog = { delete ->
-            deleteConfirmationDialogVisible = false
+            dialogVisible = false
             onCloseMenu(delete)
         },
+    )
+}
+
+@ExperimentalMaterialApi
+@Composable
+fun ExportContactsMenuItem(
+    contacts: Set<IContactBase>,
+    onExportContact: (targetFile: Uri, vCardVersion: VCardVersion) -> Unit,
+    onCancel: () -> Unit,
+) {
+    var dialogVisible: Boolean by remember { mutableStateOf(false) }
+    val multipleContacts = contacts.size > 1
+
+    DropdownMenuItem(onClick = { dialogVisible = true }) {
+        @StringRes val text = if (multipleContacts) R.string.export_contacts else R.string.export_contact
+        Text(stringResource(id = text))
+    }
+
+    ExportContactConfirmationDialog(
+        contacts = contacts,
+        visible = dialogVisible,
+        onCancel = onCancel,
+        onExport = { targetFile, vCardVersion ->
+            dialogVisible = false
+            onExportContact(targetFile, vCardVersion)
+        }
     )
 }

--- a/app/src/main/java/ch/abwesend/privatecontacts/view/components/contactmenu/ContactMenuLoadingDialogs.kt
+++ b/app/src/main/java/ch/abwesend/privatecontacts/view/components/contactmenu/ContactMenuLoadingDialogs.kt
@@ -7,10 +7,8 @@ import ch.abwesend.privatecontacts.view.components.dialogs.SimpleProgressDialog
 
 @Composable
 fun DeleteContactsLoadingDialog(deleteMultiple: Boolean) {
-    if (deleteMultiple) { // deleting one contact is so fast, a loading-screen does not make sense
-        @StringRes val title =
-            if (deleteMultiple) R.string.delete_contacts_progress
-            else R.string.delete_contact_progress
+    if (deleteMultiple) { // deleting one contact is so fast, that a loading-screen does not make sense
+        @StringRes val title = R.string.delete_contacts_progress
         SimpleProgressDialog(title = title, allowRunningInBackground = false)
     }
 }
@@ -19,5 +17,13 @@ fun DeleteContactsLoadingDialog(deleteMultiple: Boolean) {
 fun ChangeContactTypeLoadingDialog(changeMultiple: Boolean) {
     if (changeMultiple) { // changing one contact is so fast, a loading-screen does not make sense
         SimpleProgressDialog(title = R.string.type_change_progress, allowRunningInBackground = false)
+    }
+}
+
+@Composable
+fun ExportContactsLoadingDialog(exportMultiple: Boolean) {
+    if (exportMultiple) { // exporting one contact is so fast, that a loading-screen does not make sense
+        @StringRes val title = R.string.export_contacts_progress
+        SimpleProgressDialog(title = title, allowRunningInBackground = false)
     }
 }

--- a/app/src/main/java/ch/abwesend/privatecontacts/view/components/contactmenu/ContactMenuResultDialogs.kt
+++ b/app/src/main/java/ch/abwesend/privatecontacts/view/components/contactmenu/ContactMenuResultDialogs.kt
@@ -101,3 +101,32 @@ private fun ErrorsChapter(title: String, errorTexts: List<String>) {
         }
     }
 }
+
+@Composable
+fun ExportContactsResultDialog(
+    numberOfErrors: Int,
+    numberOfAttemptedChanges: Int,
+    onClose: () -> Unit
+) {
+    if (numberOfErrors > 0) {
+        val description = when {
+            numberOfAttemptedChanges == 1 -> stringResource(id = R.string.export_contact_error)
+            numberOfAttemptedChanges > numberOfErrors -> {
+                val formatArgs = arrayOf(numberOfErrors, numberOfAttemptedChanges)
+                stringResource(id = R.string.export_contacts_partial_error, formatArgs = formatArgs)
+            }
+            else -> stringResource(id = R.string.export_contacts_full_error)
+        }
+
+        OkDialog(title = R.string.error, onClose = onClose) {
+            Text(text = description)
+        }
+    } else {
+        val descriptionRes =
+            if (numberOfAttemptedChanges > 1) R.string.contacts_export_success else R.string.contact_export_success
+
+        OkDialog(title = R.string.export_complete_title, onClose = onClose) {
+            Text(text = stringResource(id = descriptionRes))
+        }
+    }
+}

--- a/app/src/main/java/ch/abwesend/privatecontacts/view/components/dialogs/YesNoDialog.kt
+++ b/app/src/main/java/ch/abwesend/privatecontacts/view/components/dialogs/YesNoDialog.kt
@@ -34,6 +34,8 @@ fun YesNoDialog(
     @StringRes title: Int,
     text: @Composable () -> Unit,
     yesButtonEnabled: Boolean = true,
+    @StringRes yesButtonLabel: Int = R.string.yes,
+    @StringRes noButtonLabel: Int = R.string.no,
     onYes: () -> Unit,
     onNo: () -> Unit,
 ) {
@@ -43,12 +45,12 @@ fun YesNoDialog(
         onDismissRequest = onNo,
         confirmButton = {
             Button(onClick = onYes, enabled = yesButtonEnabled) {
-                Text(stringResource(id = R.string.yes))
+                Text(stringResource(id = yesButtonLabel))
             }
         },
         dismissButton = {
             OutlinedButton(onClick = onNo) {
-                Text(stringResource(id = R.string.no))
+                Text(stringResource(id = noButtonLabel))
             }
         },
     )

--- a/app/src/main/java/ch/abwesend/privatecontacts/view/components/inputs/ContactTypeField.kt
+++ b/app/src/main/java/ch/abwesend/privatecontacts/view/components/inputs/ContactTypeField.kt
@@ -41,7 +41,7 @@ fun ContactTypeField(
     var showTypeInfoDialog: Boolean by remember { mutableStateOf(false) }
 
     val selectedOption = ResDropDownOption(labelRes = selectedType.label, value = selectedType)
-    val options = ContactType.values().map {
+    val options = ContactType.entries.map {
         ResDropDownOption(labelRes = it.label, value = it)
     }
 

--- a/app/src/main/java/ch/abwesend/privatecontacts/view/components/inputs/VCardVersionField.kt
+++ b/app/src/main/java/ch/abwesend/privatecontacts/view/components/inputs/VCardVersionField.kt
@@ -55,7 +55,7 @@ fun VCardVersionField(
     var showInfoDialog: Boolean by remember { mutableStateOf(false) }
 
     val selectedOption = ResDropDownOption(labelRes = selectedVersion.label, value = selectedVersion)
-    val options = VCardVersion.values().map {
+    val options = VCardVersion.entries.map {
         ResDropDownOption(labelRes = it.label, value = it)
     }
 

--- a/app/src/main/java/ch/abwesend/privatecontacts/view/screens/contactdetail/ContactDetailScreen.kt
+++ b/app/src/main/java/ch/abwesend/privatecontacts/view/screens/contactdetail/ContactDetailScreen.kt
@@ -305,7 +305,7 @@ object ContactDetailScreen {
             contacts = setOf(contact),
             onCancel = onCloseMenu,
             onExportContact = { targetFile, vCardVersion ->
-                viewModel.exportContacts(targetFile, vCardVersion, contact)
+                viewModel.exportContact(targetFile, vCardVersion, contact)
                 onCloseMenu()
             }
         )

--- a/app/src/main/java/ch/abwesend/privatecontacts/view/screens/contactdetail/ContactDetailScreen.kt
+++ b/app/src/main/java/ch/abwesend/privatecontacts/view/screens/contactdetail/ContactDetailScreen.kt
@@ -189,7 +189,7 @@ object ContactDetailScreen {
                 content = { Text(stringResource(id = R.string.refresh)) }
             )
             Divider()
-            ContactType.values().forEach { targetType ->
+            ContactType.entries.forEach { targetType ->
                 ChangeContactTypeMenuItem(
                     viewModel = viewModel,
                     contact = contact,

--- a/app/src/main/java/ch/abwesend/privatecontacts/view/screens/contactlist/ContactListTopBar.kt
+++ b/app/src/main/java/ch/abwesend/privatecontacts/view/screens/contactlist/ContactListTopBar.kt
@@ -48,6 +48,7 @@ import ch.abwesend.privatecontacts.view.components.buttons.RefreshIconButton
 import ch.abwesend.privatecontacts.view.components.buttons.SearchIconButton
 import ch.abwesend.privatecontacts.view.components.contactmenu.ChangeContactTypeMenuItem
 import ch.abwesend.privatecontacts.view.components.contactmenu.DeleteContactMenuItem
+import ch.abwesend.privatecontacts.view.components.contactmenu.ExportContactsMenuItem
 import ch.abwesend.privatecontacts.view.model.ContactListScreenState.BulkMode
 import ch.abwesend.privatecontacts.view.model.ContactListScreenState.Normal
 import ch.abwesend.privatecontacts.view.model.ContactListScreenState.Search
@@ -171,6 +172,8 @@ fun BulkModeActionsMenu(
                 )
             }
             DeleteMenuItem(viewModel, selectedContacts, onCloseMenu)
+            Divider()
+            ExportMenuItem(viewModel, selectedContacts, onCloseMenu)
         }
     }
 }
@@ -216,6 +219,23 @@ private fun DeleteMenuItem(
         }
         onCloseMenu()
     }
+}
+
+@ExperimentalMaterialApi
+@Composable
+private fun ExportMenuItem(
+    viewModel: ContactListViewModel,
+    selectedContacts: Set<IContactBase>,
+    onCloseMenu: () -> Unit,
+) {
+    ExportContactsMenuItem(
+        contacts = selectedContacts,
+        onCancel = onCloseMenu,
+        onExportContact = { targetFile, vCardVersion ->
+            viewModel.exportContacts(targetFile, vCardVersion, selectedContacts)
+            onCloseMenu()
+        }
+    )
 }
 
 @ExperimentalComposeUiApi

--- a/app/src/main/java/ch/abwesend/privatecontacts/view/screens/contactlist/ContactListTopBar.kt
+++ b/app/src/main/java/ch/abwesend/privatecontacts/view/screens/contactlist/ContactListTopBar.kt
@@ -209,7 +209,7 @@ private fun DeleteMenuItem(
     selectedContacts: Set<IContactBase>,
     onCloseMenu: () -> Unit,
 ) {
-    DeleteContactMenuItem(contacts = selectedContacts) { delete ->
+    DeleteContactMenuItem(numberOfContacts = selectedContacts.size) { delete ->
         if (delete) {
             val contactIds = selectedContacts.map { it.id }.toSet()
             viewModel.deleteContacts(contactIds)

--- a/app/src/main/java/ch/abwesend/privatecontacts/view/screens/contactlist/ContactListTopBar.kt
+++ b/app/src/main/java/ch/abwesend/privatecontacts/view/screens/contactlist/ContactListTopBar.kt
@@ -161,7 +161,7 @@ fun BulkModeActionsMenu(
         }
         if (selectedContacts.isNotEmpty()) {
             Divider()
-            ContactType.values().forEach { targetType ->
+            ContactType.entries.forEach { targetType ->
                 ChangeContactTypeMenuItem(
                     viewModel = viewModel,
                     contacts = selectedContacts,

--- a/app/src/main/java/ch/abwesend/privatecontacts/view/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/ch/abwesend/privatecontacts/view/screens/settings/SettingsScreen.kt
@@ -91,7 +91,7 @@ object SettingsScreen {
     @Composable
     private fun UxCategory(settingsRepository: SettingsRepository, currentSettings: ISettingsState) {
         val appThemeOptions = remember {
-            AppTheme.values().map { ResDropDownOption(labelRes = it.labelRes, value = it) }
+            AppTheme.entries.map { ResDropDownOption(labelRes = it.labelRes, value = it) }
         }
 
         SettingsCategory(titleRes = R.string.settings_category_ux) {
@@ -237,7 +237,7 @@ object SettingsScreen {
         currentSettings: ISettingsState,
     ) {
         val contactTypeOptions = remember {
-            ContactType.values().map { ResDropDownOption(labelRes = it.label, value = it) }
+            ContactType.entries.map { ResDropDownOption(labelRes = it.label, value = it) }
         }
         var requestPermissionsFor: ContactType? by remember { mutableStateOf(null) }
 

--- a/app/src/main/java/ch/abwesend/privatecontacts/view/viewmodel/ContactDetailViewModel.kt
+++ b/app/src/main/java/ch/abwesend/privatecontacts/view/viewmodel/ContactDetailViewModel.kt
@@ -84,7 +84,7 @@ class ContactDetailViewModel : ViewModel() {
         }
     }
 
-    fun exportContacts(targetFile: Uri, vCardVersion: VCardVersion, contact: IContact) {
+    fun exportContact(targetFile: Uri, vCardVersion: VCardVersion, contact: IContact) {
         logger.debugLocally("Exporting '${contact.displayName}' to vcf file.")
 
         viewModelScope.launch {

--- a/app/src/main/java/ch/abwesend/privatecontacts/view/viewmodel/ContactDetailViewModel.kt
+++ b/app/src/main/java/ch/abwesend/privatecontacts/view/viewmodel/ContactDetailViewModel.kt
@@ -6,16 +6,24 @@
 
 package ch.abwesend.privatecontacts.view.viewmodel
 
+import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import ch.abwesend.privatecontacts.domain.lib.flow.EventFlow
 import ch.abwesend.privatecontacts.domain.lib.flow.mutableResourceStateFlow
 import ch.abwesend.privatecontacts.domain.lib.flow.withLoadingState
+import ch.abwesend.privatecontacts.domain.lib.logging.debugLocally
+import ch.abwesend.privatecontacts.domain.lib.logging.logger
 import ch.abwesend.privatecontacts.domain.model.contact.ContactType
 import ch.abwesend.privatecontacts.domain.model.contact.IContact
 import ch.abwesend.privatecontacts.domain.model.contact.IContactBase
+import ch.abwesend.privatecontacts.domain.model.importexport.ContactExportData
+import ch.abwesend.privatecontacts.domain.model.importexport.VCardCreateError
+import ch.abwesend.privatecontacts.domain.model.importexport.VCardVersion
 import ch.abwesend.privatecontacts.domain.model.result.ContactDeleteResult
 import ch.abwesend.privatecontacts.domain.model.result.ContactSaveResult
+import ch.abwesend.privatecontacts.domain.model.result.generic.BinaryResult
+import ch.abwesend.privatecontacts.domain.service.ContactExportService
 import ch.abwesend.privatecontacts.domain.service.ContactLoadService
 import ch.abwesend.privatecontacts.domain.service.ContactSaveService
 import ch.abwesend.privatecontacts.domain.service.ContactTypeChangeService
@@ -29,6 +37,7 @@ class ContactDetailViewModel : ViewModel() {
     private val loadService: ContactLoadService by injectAnywhere()
     private val saveService: ContactSaveService by injectAnywhere()
     private val typeChangeService: ContactTypeChangeService by injectAnywhere()
+    private val exportService: ContactExportService by injectAnywhere()
     private val permissionService: PermissionService by injectAnywhere()
 
     private var latestSelectedContact: IContactBase? = null
@@ -41,6 +50,9 @@ class ContactDetailViewModel : ViewModel() {
 
     private val _typeChangeResult = EventFlow.createShared<ContactSaveResult>()
     val typeChangeResult: Flow<ContactSaveResult> = _typeChangeResult
+
+    private val _exportResult = EventFlow.createShared<BinaryResult<ContactExportData, VCardCreateError>>()
+    val exportResult: Flow<BinaryResult<ContactExportData, VCardCreateError>> = _exportResult
 
     val hasContactWritePermission: Boolean
         get() = permissionService.hasContactWritePermission()
@@ -69,6 +81,16 @@ class ContactDetailViewModel : ViewModel() {
         viewModelScope.launch {
             val result = typeChangeService.changeContactType(contact, newType)
             _typeChangeResult.emit(result)
+        }
+    }
+
+    fun exportContacts(targetFile: Uri, vCardVersion: VCardVersion, contact: IContact) {
+        logger.debugLocally("Exporting '${contact.displayName}' to vcf file.")
+
+        viewModelScope.launch {
+            val result = exportService.exportContacts(targetFile, vCardVersion, listOf(contact))
+            logger.debug("Exported vcf file: result of type ${result.javaClass.simpleName}")
+            _exportResult.emit(result)
         }
     }
 }

--- a/app/src/main/java/ch/abwesend/privatecontacts/view/viewmodel/model/BulkOperationResult.kt
+++ b/app/src/main/java/ch/abwesend/privatecontacts/view/viewmodel/model/BulkOperationResult.kt
@@ -1,0 +1,11 @@
+package ch.abwesend.privatecontacts.view.viewmodel.model
+
+import ch.abwesend.privatecontacts.domain.model.importexport.ContactExportData
+import ch.abwesend.privatecontacts.domain.model.importexport.VCardCreateError
+import ch.abwesend.privatecontacts.domain.model.result.batch.ContactIdBatchChangeResult
+import ch.abwesend.privatecontacts.domain.model.result.generic.BinaryResult
+
+data class BulkOperationResult<T>(val result: T, val numberOfSelectedContacts: Int)
+
+typealias BulkContactExportResult = BulkOperationResult<BinaryResult<ContactExportData, VCardCreateError>>
+typealias BulkContactDeleteResult = BulkOperationResult<ContactIdBatchChangeResult>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -148,7 +148,6 @@
     <string name="delete_contact">Delete Contact</string>
     <string name="delete_contact_title">Delete Contact</string>
     <string name="delete_contact_text">Deleted contacts cannot be restored. Are you sure you would like to delete this contact?</string>
-    <string name="delete_contact_progress">Contact is being deleted</string>
     <string name="delete_contact_error">Something went wrong. The contact could not be deleted.</string>
     <string name="create_as_new_contact">Create as new</string>
 
@@ -161,7 +160,7 @@
 
     <string name="make_contact_secret">Change contact to \'Secret\'</string>
     <string name="make_contact_secret_title">Change contact to \'Secret\'</string>
-    <string name="make_contact_secret_text">Changing a contact to \'Secret\' means that it is copied to this app and afterwards deleted from the public contact-database of Android.</string>
+    <string name="make_contact_secret_text">Changing a contact to \'Secret\' means that it is copied to this app and afterwards deleted from the public contact-database of Android.\n\nPlease make sure that no expected information is missing when checking the contact-details in this app before taking this step.</string>
 
     <string name="make_contacts_secret">Change contacts to \'Secret\'</string>
     <string name="make_contacts_secret_title">Change contacts to \'Secret\'</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -292,6 +292,7 @@
     <string name="import_failed_contacts">Contacts which could not be imported</string>
 
     <string name="export_title">Export</string>
+    <string name="export_contact">Export contact</string>
     <string name="export_contacts">Export contacts</string>
     <string name="select_file_to_export_to">Select .vcf file to export to</string>
     <string name="contact_type_to_export">Export contacts of type</string>
@@ -319,4 +320,14 @@
     <string name="exported_contacts">Exported contacts:</string>
     <string name="failed_to_export_contacts">Failed contacts:</string>
     <string name="no_contact_name_fallback">[No contact name]</string>
+
+    <string name="export_contact_title">Export contact</string>
+    <string name="export_contacts_title">Export contacts</string>
+    <string name="selected_for_export">selected</string>
+    <string name="contact_export_success">The contact has been successfully exported.</string>
+    <string name="contacts_export_success">The contacts have been successfully exported.</string>
+    <string name="export_contact_error">Something went wrong. The contact could not be exported.</string>
+    <string name="export_contacts_partial_error">Something went wrong. %1$s of %2$s attempted contacts could not be exported.</string>
+    <string name="export_contacts_full_error">Something went wrong. No contacts could be exported.</string>
+
 </resources>

--- a/app/src/test/java/ch/abwesend/privatecontacts/infrastructure/koin/KoinModuleTest.kt
+++ b/app/src/test/java/ch/abwesend/privatecontacts/infrastructure/koin/KoinModuleTest.kt
@@ -1,0 +1,31 @@
+package ch.abwesend.privatecontacts.infrastructure.koin
+
+import android.content.Context
+import androidx.navigation.NavHostController
+import ch.abwesend.privatecontacts.application.koinModule
+import ch.abwesend.privatecontacts.domain.lib.coroutine.ApplicationScope
+import ch.abwesend.privatecontacts.infrastructure.room.database.DatabaseHolder
+import ch.abwesend.privatecontacts.view.routing.GenericRouter
+import kotlinx.coroutines.CoroutineScope
+import org.junit.jupiter.api.Test
+import org.koin.core.annotation.KoinExperimentalAPI
+import org.koin.test.KoinTest
+import org.koin.test.verify.verify
+import kotlin.reflect.KClass
+
+@KoinExperimentalAPI
+class KoinModuleTest : KoinTest {
+    private val whiteList: List<KClass<*>> = listOf(
+        /** for the manually used constructor of [ApplicationScope] */
+        CoroutineScope::class,
+        /** for the manually used constructor of [GenericRouter] */
+        NavHostController::class,
+        /** for the manually used constructor of [DatabaseHolder] */
+        Context::class,
+    )
+
+    @Test
+    fun checkAllModules() {
+        koinModule.verify(extraTypes = whiteList)
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ buildscript {
         androidLifecycleVersion = "2.6.2"
 
         ktlintVersion = "11.3.1"
-        koinVersion = "3.1.4"
+        koinVersion = "3.5.3"
         roomVersion = "2.6.0"
         pagingVersion = "3.2.1"
         contactStoreVersion = "1.7.0"
@@ -35,7 +35,7 @@ buildscript {
         classpath 'com.android.tools.build:gradle:8.1.4'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlinVersion}"
         classpath "org.jlleitschuh.gradle:ktlint-gradle:${ktlintVersion}"
-        classpath "de.mannodermaus.gradle.plugins:android-junit5:1.8.2.0"
+        classpath "de.mannodermaus.gradle.plugins:android-junit5:1.8.2.1"
 
         classpath "com.google.gms:google-services:4.4.0"
         classpath 'com.google.firebase:firebase-crashlytics-gradle:2.9.9'

--- a/google_address_lib/src/main/java/com/google/i18n/addressinput/common/LookupKey.java
+++ b/google_address_lib/src/main/java/com/google/i18n/addressinput/common/LookupKey.java
@@ -264,7 +264,7 @@ public final class LookupKey {
      * Builds lookup keys.
      */
     // TODO: This is used in AddressWidget in a small number of places and it should be possible
-    // to hide this type within this package quite easily.
+    //   to hide this type within this package quite easily.
     public static class Builder {
         private KeyType keyType;
 


### PR DESCRIPTION
Adds the logic to export a single contact or multiple contacts to vcf (previously, the user could only export "all" contacts of a type to vcf)